### PR TITLE
fix: add compile option to skip test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,22 @@
-project (galaxy-fds-sdk-cpp)
+project(galaxy-fds-sdk-cpp)
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required(VERSION 2.8)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 aux_source_directory(src DIR_SRCS)
 
-add_library (galaxy-fds-sdk-cpp ${DIR_SRCS})
+add_library(galaxy-fds-sdk-cpp ${DIR_SRCS})
 
-target_include_directories (galaxy-fds-sdk-cpp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-include_directories(${POCO_INCLUDE} ${GTEST_INCLUDE})
-link_directories(${POCO_LIB} ${GTEST_LIB})
-add_subdirectory(sample)
-add_subdirectory(test)
+target_include_directories(galaxy-fds-sdk-cpp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+include_directories(${POCO_INCLUDE})
+link_directories(${POCO_LIB})
+
+option(WITH_TEST "enable building test" OFF)
+if (WITH_TEST)
+    include_directories(${GTEST_INCLUDE})
+    link_directories(${GTEST_LIB})
+    add_subdirectory(sample)
+    add_subdirectory(test)
+endif ()


### PR DESCRIPTION
The library users don't have to compile with test and depends on "googletest" in order to use "fds-cpp". I added a compile option called `WITH_TEST`. Normally, the compilation will skip testing. If the library developer wants to build test, he can build with:

```
cmake .. -WITH_TEST=On -DPOCO_INCLUDE=/my/poco/include -DPOCO_LIB=/my/poco/lib -DGTEST_INCLUDE=/my/gtest/include -DGTEST_LIB=/my/gtest/lib
```

This PR is tested on my machine.