### PR TITLE
fix: add override to galaxy_fds_client

### DIFF
--- a/include/galaxy_fds.h
+++ b/include/galaxy_fds.h
@@ -26,6 +26,8 @@ class MetadataBean;
 
 class GalaxyFDS {
 public:
+  virtual ~GalaxyFDS() = default;
+
   virtual std::vector<std::shared_ptr<FDSBucket> > listBuckets() = 0;
 
   virtual void createBucket(const std::string& bucketName) = 0;

--- a/include/galaxy_fds_client.h
+++ b/include/galaxy_fds_client.h
@@ -33,130 +33,130 @@ public:
 
   static const std::string DATE_FORMAT;
 
-  std::vector<std::shared_ptr<FDSBucket> > listBuckets();
+  std::vector<std::shared_ptr<FDSBucket> > listBuckets() override;
 
-  void createBucket(const std::string& bucketName);
+  void createBucket(const std::string& bucketName) override;
 
-  void deleteBucket(const std::string& bucketName);
+  void deleteBucket(const std::string& bucketName) override;
 
-  bool doesBucketExist(const std::string& bucketName);
+  bool doesBucketExist(const std::string& bucketName) override;
 
-  std::shared_ptr<AccessControlList> getBucketAcl(const std::string& bucketName);
+  std::shared_ptr<AccessControlList> getBucketAcl(const std::string& bucketName) override;
 
   void setBucketAcl(const std::string& bucketName, const AccessControlList&
-      acl);
+      acl) override;
 
-  std::shared_ptr<QuotaPolicy> getBucketQuota(const std::string& bucketName);
+  std::shared_ptr<QuotaPolicy> getBucketQuota(const std::string& bucketName) override;
 
   void setBucketQuota(const std::string& bucketName, const QuotaPolicy&
-      quotaPolicy);
+      quotaPolicy) override;
 
-  std::shared_ptr<FDSObjectListing> listObjects(const std::string& bucketName);
-
-  std::shared_ptr<FDSObjectListing> listObjects(const std::string& bucketName,
-      const std::string& prefix);
+  std::shared_ptr<FDSObjectListing> listObjects(const std::string& bucketName) override;
 
   std::shared_ptr<FDSObjectListing> listObjects(const std::string& bucketName,
-      const std::string& prefix, const std::string& delimiter);
+      const std::string& prefix) override;
+
+  std::shared_ptr<FDSObjectListing> listObjects(const std::string& bucketName,
+      const std::string& prefix, const std::string& delimiter) override;
 
   std::shared_ptr<FDSObjectListing> listNextBatchOfObjects(
-      const FDSObjectListing& previousObjectListing);
+      const FDSObjectListing& previousObjectListing) override;
 
-  std::shared_ptr<FDSObjectListing> listObjects(const std::string& bucketName, bool withMetaData);
-
-  std::shared_ptr<FDSObjectListing> listObjects(const std::string& bucketName,
-      const std::string& prefix, bool withMetaData);
+  std::shared_ptr<FDSObjectListing> listObjects(const std::string& bucketName, bool withMetaData) override;
 
   std::shared_ptr<FDSObjectListing> listObjects(const std::string& bucketName,
-      const std::string& prefix, const std::string& delimiter, bool withMetaData);
+      const std::string& prefix, bool withMetaData) override;
+
+  std::shared_ptr<FDSObjectListing> listObjects(const std::string& bucketName,
+      const std::string& prefix, const std::string& delimiter, bool withMetaData) override;
 
   std::shared_ptr<FDSObjectListing> listNextBatchOfObjects(
-      const FDSObjectListing& previousObjectListing, bool withMetaData);
+      const FDSObjectListing& previousObjectListing, bool withMetaData) override;
 
   std::shared_ptr<PutObjectResult> putObject(const std::string& bucketName,
-      const std::string& objectName, std::istream& is);
+      const std::string& objectName, std::istream& is) override;
 
   std::shared_ptr<PutObjectResult> putObject(const std::string& bucketName,
       const std::string& objectName, std::istream& is,
-      const FDSObjectMetadata& metadata);
+      const FDSObjectMetadata& metadata) override;
 
   std::shared_ptr<PutObjectResult> postObject(const std::string& bucketName,
-      std::istream& is);
+      std::istream& is) override;
 
   std::shared_ptr<PutObjectResult> postObject(const std::string& bucketName,
-      std::istream& is, const FDSObjectMetadata& metadata);
+      std::istream& is, const FDSObjectMetadata& metadata) override;
 
   std::shared_ptr<FDSObject> getObject(const std::string& bucketName,
-      const std::string& objectName);
+      const std::string& objectName) override;
 
   std::shared_ptr<FDSObject> getObject(const std::string& bucketName,
-      const std::string& objectName, long pos);
+      const std::string& objectName, long pos) override;
 
   std::shared_ptr<FDSObject> getObject(const std::string& bucketName,
-      const std::string& objectName, long pos, long len);
+      const std::string& objectName, long pos, long len) override;
 
   std::shared_ptr<FDSObjectMetadata> getObjectMetadata(const std::string&
-      bucketName, const std::string& objectName);
+      bucketName, const std::string& objectName) override;
 
   std::shared_ptr<AccessControlList> getObjectAcl(const std::string& bucketName,
-      const std::string& objectName);
+      const std::string& objectName) override;
 
   void setObjectAcl(const std::string& bucketName, const std::string&
       objectName,
-      const AccessControlList& acl);
+      const AccessControlList& acl) override;
 
   bool doesObjectExist(const std::string& bucketName, const std::string&
-      objectName);
+      objectName) override;
 
   void deleteObject(const std::string& bucketName, const std::string&
-      objectName);
+      objectName) override;
 
   void deleteObject(const std::string& bucketName, const std::string&
-      objectName, bool enableTrash);
+      objectName, bool enableTrash) override;
 
   std::shared_ptr<FDSObjectsDeleting> deleteObjects(const std::string& bucketName,
-      const std::vector<std::string>& objectNameList);
+      const std::vector<std::string>& objectNameList) override;
 
   std::shared_ptr<FDSObjectsDeleting> deleteObjects(const std::string& bucketName,
-      const std::vector<std::string>& objectNameList, bool enableTrash);
+      const std::vector<std::string>& objectNameList, bool enableTrash) override;
 
   std::shared_ptr<FDSObjectsDeleting> deleteObjects(const std::string& bucketName,
-      const std::string& prefix);
+      const std::string& prefix) override;
 
   std::shared_ptr<FDSObjectsDeleting> deleteObjects(const std::string& bucketName,
-      const std::string& prefix, bool enableTrash);
+      const std::string& prefix, bool enableTrash) override;
 
   void restoreObject(const std::string& bucketName, const std::string&
-     objectName);
+     objectName) override;
 
   void renameObject(const std::string& bucketName, const std::string&
-      srcObjectName, const std::string& dstObjectname);
+      srcObjectName, const std::string& dstObjectname) override;
 
   void prefetchObject(const std::string& bucketName, const std::string&
-      objectName);
+      objectName) override;
 
   void refreshObject(const std::string& bucketName, const std::string&
-      objectName);
+      objectName) override;
 
-  void setPublic(const std::string& bucketName, const std::string& objectName);
+  void setPublic(const std::string& bucketName, const std::string& objectName) override;
 
   std::string generateDownloadObjectUri(const std::string& bucketName,
-      const std::string& objectName);
+      const std::string& objectName) override;
 
   std::string generatePresignedUri(const std::string& bucketName,
       const std::string& objectName, time_t expiration,
-      const std::string& httpMethod);
+      const std::string& httpMethod) override;
 
   std::string generatePresignedUri(const std::string& bucketName,
       const std::string& objectName, time_t expiration,
-      const std::string& httpMethod, const std::string& contentType);
+      const std::string& httpMethod, const std::string& contentType) override;
 
   std::string generatePresignedCdnUri(const std::string& bucketName,
       const std::string& objectName, time_t expiration,
-      const std::string& httpMethod);
+      const std::string& httpMethod) override;
 
   void setObjectMetadata(const std::string& bucketName, const std::string&
-        objectName, const MetadataBean& metadata);
+        objectName, const MetadataBean& metadata) override;
 
 private:
   std::string formatUri(const std::string& baseUri, const std::string&

--- a/include/galaxy_fds_client.h
+++ b/include/galaxy_fds_client.h
@@ -31,6 +31,8 @@ public:
   GalaxyFDSClient(const std::string& accessKey, const std::string& secretKey,
       const FDSClientConfiguration& config);
 
+  ~GalaxyFDSClient() override = default;
+
   static const std::string DATE_FORMAT;
 
   std::vector<std::shared_ptr<FDSBucket> > listBuckets() override;


### PR DESCRIPTION
Some C++ compilers (clang-9) report compilation errors like:

```
error: delete called on non-final 'galaxy::fds::GalaxyFDSClient' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-abstract-non-virtual-dtor]
```

It's because that `GalaxyFDSClient` doesn't override the interfaces. This is not allowed in C++.